### PR TITLE
Watch test files and re-run when changes have been made

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+node
+====
+
+Tests
+-----
+
+    npm test

--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -1,0 +1,1 @@
+../node_modules/nodeunit/bin/nodeunit

--- a/bin/nodeunit-watcher
+++ b/bin/nodeunit-watcher
@@ -1,0 +1,1 @@
+../node_modules/nodeunit-watcher/bin/nodeunit-watcher

--- a/package.json
+++ b/package.json
@@ -1,17 +1,21 @@
 {
   "name": "node",
   "version": "0.0.0",
-  "description": "ERROR: No README.md file found!",
+  "description": "my node.js playground",
   "main": "index.js",
   "directories": {
     "example": "example"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "PATH=$PATH:./bin nodeunit-watcher library/"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/zootella/node.git"
+  },
+  "dependencies": {
+    "nodeunit": "0.7.4",
+    "nodeunit-watcher": "0.0.2"
   },
   "author": "",
   "license": "GPL",


### PR DESCRIPTION
I created a bin directory with symlinks to nodeunit to make it easier to run. (not sure if this works on windows, but it should definitely work on mac)

I added nodeunit and nodeunit-watcher as dependencies to the package.json, so you should be able to run `npm install` in the project root and it will make sure both are installed.

You can run `npm test` to actually invoke nodeunit-watcher. (it's just an npm alias defined in package.json)

nodeunit-watcher is a fairly naive approach to continuous testing; it only looks at the tests themselves to see if they need to be re-run.  Something like rails' autotest is much smarter and will figure out when you change a file and run its corresponding test, though that only works because rails has a specific directory structure.  The node tests you write will probably be so quick that you just want to re-run the entire thing anyway.
